### PR TITLE
perf: add benchmarks for stripInsertions()

### DIFF
--- a/packages/nextalign/benchmarks/CMakeLists.txt
+++ b/packages/nextalign/benchmarks/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(${PROJECT_NAME}
   src/ForwardTrace.benchmark.h
   src/Nextalign.benchmark.h
   src/SeedMatching.benchmark.h
+  src/StripInsertions.benchmark.h
   src/main.cpp
   src/utils/getData.h
   src/utils/setCounters.h

--- a/packages/nextalign/benchmarks/src/StripInsertions.benchmark.h
+++ b/packages/nextalign/benchmarks/src/StripInsertions.benchmark.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include <numeric>
+#include <vector>
+
+#include "../../src/stripInsertions.h"
+#include "../include/nextalign/nextalign.h"
+#include "../src/alignPairwise.h"
+#include "utils/getData.h"
+#include "utils/setCounters.h"
+
+
+class StripInsertionsBench : public benchmark::Fixture {
+protected:
+  std::vector<Alignment> alignments;
+
+  StripInsertionsBench() {
+    const auto n = NUM_SEQUENCES_AVG;
+    alignments.resize(n);
+    for (int i = 0; i < n; ++i) {
+      const auto& input = sequences[i];
+      alignments[i] = alignPairwise(input.seq, reference, &lookupNucMatchScore, 100);
+    }
+  }
+};
+
+
+BENCHMARK_DEFINE_F(StripInsertionsBench, Average)(benchmark::State& st) {
+  const auto n = NUM_SEQUENCES_AVG;
+  StripInsertionsResult result;
+  st.SetComplexityN(totalNucs);
+
+  for (const auto _ : st) {
+    for (int i = 0; i < n; ++i) {
+      const auto& input = sequences[i];
+      const auto& seedAlignment = alignments[i];
+      benchmark::DoNotOptimize(result = stripInsertions(reference, input.seq));
+    }
+  }
+
+  setCounters(st, n);
+}
+
+
+BENCHMARK_REGISTER_F(StripInsertionsBench, Average)
+  ->Unit(benchmark::kMillisecond)//
+  ->Complexity(benchmark::oNSquared)
+  ->Iterations(3);
+
+
+BENCHMARK_DEFINE_F(StripInsertionsBench, Variation)(benchmark::State& st) {
+  const auto& index = st.range(0);
+  const auto& input = sequences[index];
+  StripInsertionsResult result;
+  st.SetLabel(input.seqName);
+  st.SetComplexityN(input.seq.size());
+
+  for (const auto _ : st) {
+    benchmark::DoNotOptimize(result = stripInsertions(reference, input.seq));
+  }
+
+  setCounters(st, 1);
+}
+
+BENCHMARK_REGISTER_F(StripInsertionsBench, Variation)
+  ->DenseRange(0, NUM_SEQUENCES_VAR - 1, 1)//
+  ->Unit(benchmark::kMillisecond)          //
+  ->Complexity(benchmark::oNSquared);

--- a/packages/nextalign/benchmarks/src/main.cpp
+++ b/packages/nextalign/benchmarks/src/main.cpp
@@ -10,6 +10,7 @@ const auto [sequences, reference, geneMap, totalNucs] = getData();
 #include "SeedMatching.benchmark.h"
 #include "ForwardTrace.benchmark.h"
 #include "BackwardTrace.benchmark.h"
+#include "StripInsertions.benchmark.h"
 // clang-format on
 
 


### PR DESCRIPTION
Adds becnhmarks for the insertion stripping step. Turns out it is surprisingly fast (~2800 seq/s), considering all the string concatenation involved.