### PR TITLE
chore: build CLI as a standalone static executable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/*
+!.build/Release/packages/nextalign_cli/nextalign_cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY .build/Release/packages/nextalign_cli/nextalign_cli /nextalign
+
+ENTRYPOINT ["/nextalign"]

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -13,3 +13,7 @@ cmake
 txt
 cmake_find_package
 cmake_paths
+
+[options]
+tbb:shared=False
+gtest:shared=True

--- a/packages/nextalign_cli/CMakeLists.txt
+++ b/packages/nextalign_cli/CMakeLists.txt
@@ -34,4 +34,5 @@ target_link_libraries(${PROJECT_NAME}
   fmt::fmt
   nextalign
   TBB::tbb
+  -static -static-libstdc++ -static-libgcc
   )


### PR DESCRIPTION
This modifies CLI build such that it produces fully* standalone statically linked executable for Linux. It is able to run in a docker container `FROM scratch`:

https://github.com/neherlab/nextalign/blob/6a8eae8f6ddfb2bca2ed8d6a2cb3424be1d0d72d/Dockerfile#L1-L5


<sub>*see caveats below</sub>

Caveats:
 - Intel TBB strongly discourages usage of static linkage (and its conan package emits a warning)
 - glibc still links things like locales and some of the networking dynamically. We don't use any of this, but if we accidentally do, the executable might not run on other machines.
 - In general, static linking is frowned upon (see e.g. [Static Linking Considered Harmful](https://www.akkadia.org/drepper/no_static_linking.html))

