### PR TITLE
perf: move ref sequence transform out of the loop

### DIFF
--- a/packages/nextalign/CMakeLists.txt
+++ b/packages/nextalign/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(${PROJECT_NAME} STATIC
   src/align/alignPairwise.h
   src/alphabet/aminoacids.cpp
   src/alphabet/aminoacids.h
-  src/alphabet/letter.h
   src/alphabet/nucleotides.cpp
   src/alphabet/nucleotides.h
   src/io/gene.io.cpp

--- a/packages/nextalign/benchmarks/src/AlignPairwise.benchmark.h
+++ b/packages/nextalign/benchmarks/src/AlignPairwise.benchmark.h
@@ -5,10 +5,10 @@
 #include <numeric>
 #include <vector>
 
-#include "../../src/align/alignPairwise.h"
-#include "../../src/match/matchNuc.h"
 #include "../include/nextalign/nextalign.h"
+#include "../src/align/alignPairwise.h"
 #include "../src/alphabet/nucleotides.h"
+#include "../src/match/matchNuc.h"
 #include "utils/getData.h"
 #include "utils/setCounters.h"
 

--- a/packages/nextalign/benchmarks/src/BackwardTrace.benchmark.h
+++ b/packages/nextalign/benchmarks/src/BackwardTrace.benchmark.h
@@ -5,8 +5,8 @@
 #include <numeric>
 #include <vector>
 
-#include "../../src/align/alignPairwise.h"
 #include "../include/nextalign/nextalign.h"
+#include "../src/align/alignPairwise.h"
 #include "utils/getData.h"
 #include "utils/setCounters.h"
 

--- a/packages/nextalign/benchmarks/src/ForwardTrace.benchmark.h
+++ b/packages/nextalign/benchmarks/src/ForwardTrace.benchmark.h
@@ -5,8 +5,8 @@
 #include <numeric>
 #include <vector>
 
-#include "../../src/align/alignPairwise.h"
 #include "../include/nextalign/nextalign.h"
+#include "../src/align/alignPairwise.h"
 #include "utils/getData.h"
 #include "utils/setCounters.h"
 

--- a/packages/nextalign/benchmarks/src/SeedMatching.benchmark.h
+++ b/packages/nextalign/benchmarks/src/SeedMatching.benchmark.h
@@ -5,8 +5,8 @@
 #include <numeric>
 #include <vector>
 
-#include "../../src/align/alignPairwise.cpp"
 #include "../include/nextalign/nextalign.h"
+#include "../src/align/alignPairwise.cpp"
 #include "utils/getData.h"
 #include "utils/setCounters.h"
 

--- a/packages/nextalign/benchmarks/src/StripInsertions.benchmark.h
+++ b/packages/nextalign/benchmarks/src/StripInsertions.benchmark.h
@@ -5,9 +5,9 @@
 #include <numeric>
 #include <vector>
 
-#include "../../src/align/alignPairwise.h"
-#include "../../src/strip/stripInsertions.h"
 #include "../include/nextalign/nextalign.h"
+#include "../src/align/alignPairwise.h"
+#include "../src/strip/stripInsertions.h"
 #include "utils/getData.h"
 #include "utils/setCounters.h"
 

--- a/packages/nextalign/include/nextalign/nextalign.h
+++ b/packages/nextalign/include/nextalign/nextalign.h
@@ -8,6 +8,80 @@
 #include <string>
 #include <vector>
 
+template<typename Letter>
+using Sequence = std::basic_string<Letter>;
+
+
+enum class Nucleotide : char {
+  U = 0,
+  T = 1,
+  A = 2,
+  W = 3,
+  C = 4,
+  Y = 5,
+  M = 6,
+  H = 7,
+  G = 8,
+  K = 9,
+  R = 10,
+  D = 11,
+  S = 12,
+  B = 13,
+  V = 14,
+  N = 15,
+  GAP = 16,
+  SIZE = 17,
+};
+
+using NucleotideSequence = Sequence<Nucleotide>;
+
+NucleotideSequence toNucleotideSequence(const std::string& seq);
+
+std::string toString(const NucleotideSequence& seq);
+
+
+constexpr const char CHAR_AMINOACID_UNKNOWN = 'X';
+constexpr const char CHAR_AMINOACID_GAP = '-';
+constexpr const char CHAR_AMINOACID_STOP = '*';
+
+enum class Aminoacid : char {
+  A = 0,
+  B = 1,// D | N
+  C = 2,
+  D = 3,
+  E = 4,
+  F = 5,
+  G = 6,
+  H = 7,
+  I = 8,
+  J = 9,// L | I
+  K = 10,
+  L = 11,
+  M = 12,
+  N = 13,
+  O = 14,// (rare) Pyrrolysine
+  P = 15,
+  Q = 16,
+  R = 17,
+  S = 18,
+  T = 19,
+  U = 20,// (rare) Selenocysteine
+  V = 21,
+  W = 22,
+  Y = 23,
+  Z = 24,// E | Q
+  X = 25,
+  STOP = 26,
+  GAP = 27,
+  SIZE,
+};
+
+using AminoacidSequence = Sequence<Aminoacid>;
+
+AminoacidSequence toAminoacidSequence(const std::string& seq);
+
+std::string toString(const AminoacidSequence& seq);
+
 
 struct AlgorithmInput {
   int index;
@@ -55,8 +129,8 @@ struct AlgorithmOutput {
 };
 
 
-AlignmentImproved nextalign(
-  const std::string& query, const std::string& ref, const GeneMap& geneMap, const NextalignOptions& options);
+AlignmentImproved nextalign(const NucleotideSequence& query, const NucleotideSequence& ref, const GeneMap& geneMap,
+  const NextalignOptions& options);
 
 /**
  * Parses genemap in GFF format from a file or string stream

--- a/packages/nextalign/src/align/alignPairwise.cpp
+++ b/packages/nextalign/src/align/alignPairwise.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "../alphabet/aminoacids.h"
-#include "../alphabet/letter.h"
 #include "../alphabet/nucleotides.h"
 #include "../match/matchAa.h"
 #include "../match/matchNuc.h"

--- a/packages/nextalign/src/alphabet/aminoacids.h
+++ b/packages/nextalign/src/alphabet/aminoacids.h
@@ -1,55 +1,14 @@
 #pragma once
 
+#include <nextalign/nextalign.h>
+
 #include <string>
 
 #include "../utils/to_underlying.h"
-#include "letter.h"
-
-constexpr const char CHAR_AMINOACID_UNKNOWN = 'X';
-constexpr const char CHAR_AMINOACID_GAP = '-';
-constexpr const char CHAR_AMINOACID_STOP = '*';
-
-enum class Aminoacid : char {
-  A = 0,
-  B = 1,// D | N
-  C = 2,
-  D = 3,
-  E = 4,
-  F = 5,
-  G = 6,
-  H = 7,
-  I = 8,
-  J = 9,// L | I
-  K = 10,
-  L = 11,
-  M = 12,
-  N = 13,
-  O = 14,// (rare) Pyrrolysine
-  P = 15,
-  Q = 16,
-  R = 17,
-  S = 18,
-  T = 19,
-  U = 20,// (rare) Selenocysteine
-  V = 21,
-  W = 22,
-  Y = 23,
-  Z = 24,// E | Q
-  X = 25,
-  STOP = 26,
-  GAP = 27,
-  SIZE,
-};
-
-using AminoacidSequence = Sequence<Aminoacid>;
 
 Aminoacid toAminoacid(char aa);
 
 char toChar(Aminoacid aa);
-
-AminoacidSequence toAminoacidSequence(const std::string& seq);
-
-std::string toString(const AminoacidSequence& seq);
 
 inline std::ostream& operator<<(std::ostream& os, const Aminoacid& aminoacid) {
   os << std::string{to_underlying(aminoacid)};

--- a/packages/nextalign/src/alphabet/letter.h
+++ b/packages/nextalign/src/alphabet/letter.h
@@ -1,4 +1,0 @@
-#pragma once
-
-template<typename Letter>
-using Sequence = std::basic_string<Letter>;

--- a/packages/nextalign/src/alphabet/nucleotides.h
+++ b/packages/nextalign/src/alphabet/nucleotides.h
@@ -1,40 +1,14 @@
 #pragma once
 
+#include <nextalign/nextalign.h>
+
 #include <string>
 
 #include "../utils/to_underlying.h"
-#include "letter.h"
-
-enum class Nucleotide : char {
-  U = 0,
-  T = 1,
-  A = 2,
-  W = 3,
-  C = 4,
-  Y = 5,
-  M = 6,
-  H = 7,
-  G = 8,
-  K = 9,
-  R = 10,
-  D = 11,
-  S = 12,
-  B = 13,
-  V = 14,
-  N = 15,
-  GAP = 16,
-  SIZE = 17,
-};
-
-using NucleotideSequence = Sequence<Nucleotide>;
 
 Nucleotide toNucleotide(char nuc);
 
 char toChar(Nucleotide nuc);
-
-NucleotideSequence toNucleotideSequence(const std::string& seq);
-
-std::string toString(const NucleotideSequence& seq);
 
 inline std::ostream& operator<<(std::ostream& os, const Nucleotide& nucleotide) {
   os << std::string{to_underlying(nucleotide)};

--- a/packages/nextalign/src/nextalign.cpp
+++ b/packages/nextalign/src/nextalign.cpp
@@ -9,15 +9,13 @@
 #include "utils/map.h"
 #include "utils/safe_cast.h"
 
+
 Insertion toExternal(const InsertionInternal& ins) {
   return Insertion{.begin = ins.begin, .end = ins.end, .seq = toString(ins.seq)};
 }
 
-AlignmentImproved nextalign(
-  const std::string& queryStr, const std::string& refStr, const GeneMap& geneMap, const NextalignOptions& options) {
-
-  const auto query = toNucleotideSequence(queryStr);
-  const auto ref = toNucleotideSequence(refStr);
+AlignmentImproved nextalign(const NucleotideSequence& query, const NucleotideSequence& ref, const GeneMap& geneMap,
+  const NextalignOptions& options) {
 
   const auto alignment = alignPairwise(query, ref, 100);
   const auto stripped = stripInsertions(alignment.ref, alignment.query);

--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -333,12 +333,14 @@ void run(
   /* in  */ int parallelism,
   /* in  */ const CliParams &cliParams,
   /* out */ std::unique_ptr<FastaStream> &inputFastaStream,
-  /* in  */ const std::string &ref,
+  /* in  */ const std::string &refStr,
   /* in  */ const GeneMap &geneMap,
   /* in  */ const NextalignOptions &options,
   /* out */ std::ostream &outputFastaStream,
   /* out */ std::ostream &outputInsertionsStream) {
   tbb::task_group_context context;
+
+  const auto ref = toNucleotideSequence(refStr);
 
   /** Input filter is a serial input filter function, which accepts an input stream,
    * reads and parses the contents of it, and returns parsed sequences */
@@ -359,7 +361,8 @@ void run(
   const auto transformFilters = tbb::make_filter<AlgorithmInput, AlgorithmOutput>(tbb::filter::parallel,//
     [&ref, &geneMap, &options](const AlgorithmInput &input) -> AlgorithmOutput {
       try {
-        const auto result = nextalign(input.seq, ref, geneMap, options);
+        const auto query = toNucleotideSequence(input.seq);
+        const auto result = nextalign(query, ref, geneMap, options);
         return {.index = input.index, .seqName = input.seqName, .hasError = false, .result = result, .error = nullptr};
       } catch (const std::exception &e) {
         const auto &error = std::current_exception();


### PR DESCRIPTION

This moves ref sequence transformation from string to the internal representation out of the main loop.

Unfortunately, this now publicly exposes many previously internal interfaces - types and functions.
