### PR TITLE
fix: resolve Clang error about template template type deduction

### DIFF
--- a/packages/nextalign/src/utils/map.h
+++ b/packages/nextalign/src/utils/map.h
@@ -2,10 +2,28 @@
 
 #include <algorithm>
 #include <functional>
+#include <string>
+#include <vector>
 
-template<typename Input, typename Output, template<typename> typename Container>
-Container<Output> map(const Container<Input>& input, std::function<Output(Input)> op) {
-  Container<Output> result = {};
+//template<typename Input, typename Output, template<typename> typename Container>
+//Container<Output> map(const Container<Input>& input, std::function<Output(Input)> op) {
+//  Container<Output> result = {};
+//  result.reserve(input.size());
+//  std::transform(input.cbegin(), input.cend(), std::back_inserter(result), op);
+//  return result;
+//}
+
+template<typename Input, typename Output>
+inline std::basic_string<Output> map(const std::basic_string<Input>& input, std::function<Output(Input)> op) {
+  std::basic_string<Output> result = {};
+  result.reserve(input.size());
+  std::transform(input.cbegin(), input.cend(), std::back_inserter(result), op);
+  return result;
+}
+
+template<typename Input, typename Output>
+inline std::vector<Output> map(const std::vector<Input>& input, std::function<Output(Input)> op) {
+  std::vector<Output> result = {};
   result.reserve(input.size());
   std::transform(input.cbegin(), input.cend(), std::back_inserter(result), op);
   return result;


### PR DESCRIPTION
I went a bit too deep into templates here. Not entirely sure why Clang won't resolve the types here, while GCC does. Probably my fault. Might tinker a bit later.

Meanwhile, for a quick fix, I just made 2 versions for strings and vectors, to be more explicit, at the cost of code duplication.

