### PR TITLE
refactor: remove redundant uninitialized field

### DIFF
--- a/packages/nextalign/src/translate/translateGenes.h
+++ b/packages/nextalign/src/translate/translateGenes.h
@@ -9,7 +9,6 @@
 struct PeptidesInternal {
   std::vector<PeptideInternal> queryPeptides;
   std::vector<PeptideInternal> refPeptides;
-  std::vector<InsertionInternal<Aminoacid>> insertions;
   std::vector<std::string> warnings;
 };
 


### PR DESCRIPTION
Aminoacid insertions are gathered per gene now, so this filed is no longer used