### PR TITLE
fix: iterate by reference

### DIFF
--- a/packages/nextalign_cli/src/cli.cpp
+++ b/packages/nextalign_cli/src/cli.cpp
@@ -305,7 +305,7 @@ Paths getPaths(const CliParams &cliParams, const std::set<std::string> &genes) {
   }
 
   std::map<std::string, std::filesystem::path> outputGenes;
-  for (const auto gene : genes) {
+  for (const auto& gene : genes) {
     auto outputGene = outDir / baseName;
     outputGene += fmt::format(".gene.{:s}.fasta", gene);
     outputGenes.emplace(gene, outputGene);


### PR DESCRIPTION
This statement was creating a copy on every iteration, but now uses reference type to avoid that.